### PR TITLE
Bug Fix: Changed ordering of slices from alphabetical to numerical.

### DIFF
--- a/R/plotSlice.R
+++ b/R/plotSlice.R
@@ -85,10 +85,9 @@ plotSlice <- function(x, fix, a.facet = list(), ...){
   plts <- alply(indx, 1,
                 function(.vr, ...){
                   .d <- plot(x, fix = .vr, ...)$data 
-                  .val <- paste0(names(.vr), "=", as.factor(.vr))
-                  .d$fit[paste0(".fx.", names(.vr))] <- drop(matrix(rep(.val, each = nrow(.d$fit)), 
+                  .d$fit[paste0(".fx.", names(.vr))] <- drop(matrix(rep(.vr, each = nrow(.d$fit)), 
                                                                     nrow(.d$fit), nfx))
-                  .d$res[paste0(".fx.", names(.vr))] <- drop(matrix(rep(.val, each = nrow(.d$res)), 
+                  .d$res[paste0(".fx.", names(.vr))] <- drop(matrix(rep(.vr, each = nrow(.d$res)), 
                                                                     nrow(.d$res), nfx))
                   return(.d)
                 }, ...) 
@@ -105,6 +104,13 @@ plotSlice <- function(x, fix, a.facet = list(), ...){
     labs(title = lbs$title, x = lbs$x, y = lbs$y) + 
     theme_bw() +
     theme(panel.grid.major = element_blank(), panel.grid.minor = element_blank())
+  
+  if( is.null(a.facet$labeller) ){ a.facet$labeller <- function (labels, multi_line = TRUE, sep = "=") {
+                                                          .labels <- label_both(labels, multi_line = TRUE, sep)
+                                                          .labels <- lapply(.labels, function(x) substring(x ,5))  # Drop .fx. prefix from labels
+                                                          return(.labels)
+                                                       }
+  }
   
   if( grD == 1 ){
     if( is.null(a.facet$nrow) && is.null(a.facet$ncol) ){ a.facet$ncol <- floor(sqrt(nsl)) }


### PR DESCRIPTION
Hello Matteo,

with the old labeling the slices were ordered alphabetically by facet_wrap() or facet_grid(). This error occurred because I wanted slices for c(50,100,150,200). I attached example code at the end.

For the new labeller I used the functions provided by ggplot2. This gives me the ability to add an option to change the separator. My idea would be to add it to the function options: 
`plotSlice <- function(x, fix, sep = "=", a.facet = list(), ...)`

But I wanted to first ask, if this is ok with you?

BTW I love your work.

Greetings,
Alex

```
library(mgcViz)
n <- 1e3
x <- rnorm(n, mean = 200, sd = 75); y <- rnorm(n, mean = 200, sd = 75); z <- rnorm(n, mean = 200, sd = 75); z2 <- rnorm(n, mean = 200, sd = 75)
ob <- (x-z)^2 + (y-z)^2 + rnorm(n)
b <- gamV(ob ~ s(x, y, z))
plotSlice(x = sm(b, 1), fix = list("z" = c(10,30,50,100,200,400))) + l_fitRaster() + l_fitContour() + l_points() + l_rug()

ob2 <- (x-z)^2 + (y-z)^2 + z2^3 + rnorm(n)
b2 <- gamV(ob2 ~ s(x, y, z, z2))
plotSlice(x = sm(b2, 1), fix = list("z" = c(10,30,50,100,200,400), "z2" = c(10,30,50,100,200,400))) + 
  l_fitRaster() + l_fitContour() + l_points() + l_rug()
```