### PR TITLE
Change Legend labeling for mqgam smooth plots and fix #53

### DIFF
--- a/R/plot_mgcv_smooth_1D.R
+++ b/R/plot_mgcv_smooth_1D.R
@@ -22,7 +22,9 @@
 #'                   that TRUE results in better coverage performance, and this is also suggested 
 #'                   by simulation.
 #' @param nsim number of smooth effect curves to be simulated from the posterior distribution. 
-#'             These can be plotted using the \link{l_simLine} layer. See Examples section below.  
+#'             These can be plotted using the \link{l_simLine} layer. See Examples section below. 
+#' @param asFact whether to use a factor or colour bar legend for plot.multi.mgcv.smooth.1D. 
+#'               Default is \code{FALSE} for less than 10 quantiles. 
 #' @param ... currently unused.
 #' @return An objects of class \code{plotSmooth}.
 #' @references Marra, G and S.N. Wood (2012) Coverage Properties of Confidence Intervals for 

--- a/R/plot_multi_mgcv_smooth_1D.R
+++ b/R/plot_multi_mgcv_smooth_1D.R
@@ -4,7 +4,7 @@
 #' @export
 #'
 plot.multi.mgcv.smooth.1D <- function(x, n = 100, xlim = NULL, maxpo = 1e4, trans = identity,
-                                      unconditional = FALSE, seWithMean = FALSE, ...) {
+                                      unconditional = FALSE, seWithMean = FALSE, asFact = NULL, ...) {
   
   # 1) Prepare data
   tmp <- lapply(x, function(.inp) plot(.inp, n = n, xlim = xlim, maxpo = maxpo, trans = trans, 
@@ -17,7 +17,7 @@ plot.multi.mgcv.smooth.1D <- function(x, n = 100, xlim = NULL, maxpo = 1e4, tran
   names( P$data ) <- names( x )
   
   # 2) Produce output object
-  out <- .plot.multi.mgcv.smooth.1D(P = P, trans = trans)
+  out <- .plot.multi.mgcv.smooth.1D(P = P, trans = trans, asFact = asFact)
   
   class(out) <- c("plotSmooth", "gg")
   
@@ -26,7 +26,7 @@ plot.multi.mgcv.smooth.1D <- function(x, n = 100, xlim = NULL, maxpo = 1e4, tran
 
 ############### Internal function
 #' @noRd
-.plot.multi.mgcv.smooth.1D <- function(P = P, trans = trans) {
+.plot.multi.mgcv.smooth.1D <- function(P = P, trans = trans, asFact) {
   
   .fitDat <- lapply(P$data, "[[", "fit")
   
@@ -46,10 +46,20 @@ plot.multi.mgcv.smooth.1D <- function(x, n = 100, xlim = NULL, maxpo = 1e4, tran
   
   .pl <- ggplot(data = .dat$fit, aes("x" = x, "y" = ty, "colour" = id, "group" = id)) +
     labs(title = P$main, x = P$xlab, y = P$ylab) + 
-    scale_color_gradient(breaks = sort(.idNam, decreasing = T)) +
-    guides(color = guide_legend(override.aes = list(size = 5))) +
     theme_bw() +
     theme(panel.grid.major = element_blank(), panel.grid.minor = element_blank())
+  
+  if (is.null(asFact)) 
+    if (length(.idNam)<10) { asFact=T } else { asFact=F }
+  
+  if (asFact == T) {
+    .pl <- .pl + scale_color_gradient(breaks = sort(.idNam, decreasing = T)) +
+                 guides(color = guide_legend(override.aes = list(size = 5)))
+  } else {
+    if (min(diff(sort(.idNam)))>0.099) { # Ticks will be plotted if they are more than 10% apart, rounding error prevents >=0.1
+      .pl <- .pl + scale_color_gradient(breaks = sort(.idNam, decreasing = T))
+    }
+  }
   
   return( list("ggObj" = .pl, "data" = .dat, "type" = c("Multi", "1D")) ) 
   

--- a/R/plot_multi_mgcv_smooth_1D.R
+++ b/R/plot_multi_mgcv_smooth_1D.R
@@ -46,6 +46,8 @@ plot.multi.mgcv.smooth.1D <- function(x, n = 100, xlim = NULL, maxpo = 1e4, tran
   
   .pl <- ggplot(data = .dat$fit, aes("x" = x, "y" = ty, "colour" = id, "group" = id)) +
     labs(title = P$main, x = P$xlab, y = P$ylab) + 
+    scale_color_gradient(breaks = sort(.idNam, decreasing = T)) +
+    guides(color = guide_legend(override.aes = list(size = 5))) +
     theme_bw() +
     theme(panel.grid.major = element_blank(), panel.grid.minor = element_blank())
   

--- a/R/plot_multi_ptermFactor.R
+++ b/R/plot_multi_ptermFactor.R
@@ -57,8 +57,9 @@ plot.multi.ptermFactor <- function(x, a.facet = list(), asFact = TRUE, ...) {
     if( is.numeric(.idNam) ){ .idNam <- round(as.numeric(levels(.dat$fit$id)), 3) }
     .pl <- .pl + scale_x_discrete(labels = .idNam) + scale_colour_discrete(labels = .idNam)
   } else {
-    .pl <- .pl + scale_color_gradient(breaks = sort(.idNam, decreasing = T)) +
-                 guides(color = guide_legend()) 
+    if (min(diff(sort(.idNam)))>0.099) { # Ticks will be plotted if they are more than 10% apart, rounding error prevents >=0.1
+      .pl <- .pl + scale_color_gradient(breaks = sort(.idNam, decreasing = T))
+    }
   }
   
   if( is.null(a.facet$facets) ){ a.facet$facets <- as.formula("~ x") }

--- a/R/plot_multi_ptermFactor.R
+++ b/R/plot_multi_ptermFactor.R
@@ -50,12 +50,15 @@ plot.multi.ptermFactor <- function(x, a.facet = list(), asFact = TRUE, ...) {
   
   .dat$misc <- list("trans" = trans)
   
-  .pl <- ggplot(data = .dat$fit, aes("x" = id, "y" = ty)) + labs(title = NULL, x = P$xlab, y = P$ylab) + 
+  .pl <- ggplot(data = .dat$fit, aes("x" = id, "y" = ty)) + labs(title = NULL, y = P$ylab) +
          theme_bw() + theme(panel.grid.major = element_blank(), panel.grid.minor = element_blank()) 
   
   if( asFact ){
     if( is.numeric(.idNam) ){ .idNam <- round(as.numeric(levels(.dat$fit$id)), 3) }
     .pl <- .pl + scale_x_discrete(labels = .idNam) + scale_colour_discrete(labels = .idNam)
+  } else {
+    .pl <- .pl + scale_color_gradient(breaks = sort(.idNam, decreasing = T)) +
+                 guides(color = guide_legend()) 
   }
   
   if( is.null(a.facet$facets) ){ a.facet$facets <- as.formula("~ x") }

--- a/man/plot.mgcv.smooth.1D.Rd
+++ b/man/plot.mgcv.smooth.1D.Rd
@@ -7,12 +7,12 @@
 \title{Plotting one dimensional smooth effects}
 \usage{
 \method{plot}{mgcv.smooth.1D}(x, n = 100, xlim = NULL, maxpo = 10000,
-  trans = identity, unconditional = FALSE, seWithMean = FALSE, nsim = 0,
-  ...)
+  trans = identity, unconditional = FALSE, seWithMean = FALSE,
+  nsim = 0, ...)
 
 \method{plot}{multi.mgcv.smooth.1D}(x, n = 100, xlim = NULL,
   maxpo = 10000, trans = identity, unconditional = FALSE,
-  seWithMean = FALSE, ...)
+  seWithMean = FALSE, asFact = NULL, ...)
 }
 \arguments{
 \item{x}{a smooth effect object, extracted using \link[mgcViz:sm]{mgcViz::sm}.}
@@ -44,6 +44,9 @@ by simulation.}
 These can be plotted using the \link{l_simLine} layer. See Examples section below.}
 
 \item{...}{currently unused.}
+
+\item{asFact}{whether a factor or colour bar legend should be used for plot.multi.mgcv.smooth.1D.
+Default is \code{FALSE} for less than 10 quantiles.}
 }
 \value{
 An objects of class \code{plotSmooth}.


### PR DESCRIPTION
Hello Matteo,

this pull request is a change in the legend of mqgam smooth plots. In the current state it is really hard to deduce the quantiles used for calculation from the figure. I change the legend to explicitly state them. The color scale (default ggplot blue) is unchanged. But there are 2 options. The version I picked is in my opinion the clearer option (first figure). The second figure keeps the colorbar, but the ticks are only rendered for used quantiles. (This is controlled by deleting Line 50 in plot_multi_mgcv_smooth_1D.R)

I also fixed issue #53 and added the new legend to asFact=F. The third figure is the version I choose for this pull request. I prefer the 4th figure, because the color of the bigger points is easier to see. Again the last version is keeping the colorbar (5th fig.).

The strange errorbar width is created in L_ciBar.R at Line 44. 
`if( is.null(a$width) ){ a$width <- 0.5 }`
Inside this function I can't see if the x-axis is discrete or continuous. Also, I'm not sure where this function is called, when plotting with plot.mgamViz.

Please tell me which version you prefer and I will change the code accordingly. My test script is at the end. 

Greetings
Alex

1.
![smooth_discrete_legend](https://user-images.githubusercontent.com/5631424/52539262-5cf0f280-2d7c-11e9-80fc-b290176ba227.png)
2.
![smooth_colorbar](https://user-images.githubusercontent.com/5631424/52539263-60847980-2d7c-11e9-9456-ab67dc2c8554.png)
3.
![factor_points_normal](https://user-images.githubusercontent.com/5631424/52539392-fa005b00-2d7d-11e9-87fc-04f79bd43886.png)
4.
![factor_point_big](https://user-images.githubusercontent.com/5631424/52539400-05538680-2d7e-11e9-8e06-2a4c7a49b57a.png)
5.
![factor_colorbar](https://user-images.githubusercontent.com/5631424/52539402-071d4a00-2d7e-11e9-852f-aa7069462a5d.png)

```
library(mgcViz)
dat <- gamSim(4, n=300, dist="normal", scale=2)

fit <- mqgamV(y~ fac + s(x1), data=dat, err = 0.05, qu = c(0.2, 0.8, 0.5))

plot(fit, select=1)
plot(fit, select=2, asFact=T)
plot(fit, select=2, asFact=F)
```