### PR TITLE
multi gams are always treated as discrete. Fix L_ciBar

### DIFF
--- a/R/L_ciBar.R
+++ b/R/L_ciBar.R
@@ -41,7 +41,8 @@ l_ciBar.PtermFactor <- l_ciBar.MultiPtermNumeric <- l_ciBar.MultiPtermFactor <- 
   .dat$lci <- .trans( .dat$y - xtra$mul * .dat$se )
   a$data <- .dat
   
-  if( is.null(a$width) ){ a$width <- 0.5 }
+  if( is.null(a$width) )
+    if( is.factor(a$data$id) | is.null(a$data$id) ){ a$width <- 0.5 }
   if( is.null(a$linetype) ){ a$linetype <- 2 }
   
   a$mapping <- aes(ymin = lci, ymax = uci)

--- a/R/plot_multi_mgcv_smooth_1D.R
+++ b/R/plot_multi_mgcv_smooth_1D.R
@@ -39,6 +39,7 @@ plot.multi.mgcv.smooth.1D <- function(x, n = 100, xlim = NULL, maxpo = 1e4, tran
                          "y" = as.vector( sapply(.fitDat, "[[", "y") ), 
                          "ty" = as.vector( sapply(.fitDat, "[[", "ty") ),  
                          "id" = rep(.idNam, each = length(.fitDat[[1]]$x)))
+  if( !isMQGAM ){ .dat$fit$id <- as.factor( .dat$fit$id ) } 
   
   .dat$res <- P$data[[1]]$res
   .dat$res$y <- NULL


### PR DESCRIPTION
Oh I wasn't aware of this functionality. I'm sorry for breaking so much. 

While testing your fix, I accidentally forgot to label the models:
`names(mods) <- c("M1", "M2", "M3", "M4")`
In this case the list index is treated as numerical, which results in a colour bar legend. I added a line to convert the `id` for normal multi gams to a factor like you did in `plot.multi.ptermFactor`

Also, I found a solution for the `L_ciBar` problem. It is quite a hack. You can check if the `id` column exists and if it is a factor. `id` will be a factor for discrete x-axes and numerical for continuous x-axes. For now the errorbar in the continuous case will use the ggplot default width.

If you add:
`else { a$width <- min(diff(sort(unique(a$data$id))))/2 }`
you get smaller errorbars, but since the user already specified `asFact=FALSE` he can also specify the width. But if you like this solution I can add it.

I think if you split `l_ciBar.MultiPtermNumeric and l_ciBar.MultiPtermFactor` into a new function, you can drop the check whether the `id` column exists.

Best,
Alex