### PR TITLE
Retire `facet_grid(facets)`

### DIFF
--- a/R/plotSlice.R
+++ b/R/plotSlice.R
@@ -118,7 +118,7 @@ plotSlice <- function(x, fix, a.facet = list(), ...){
     .pl <- .pl + do.call("facet_wrap", a.facet)
   }
   if( grD == 2 ){
-    if( is.null(a.facet$facets) ){ a.facet$facets <- paste0(".fx.", gridVar[1], " ~ .fx.", gridVar[2]) }
+    if( is.null(a.facet$rows) ){ a.facet$rows <- paste0(".fx.", gridVar[1], " ~ .fx.", gridVar[2]) }
     .pl <- .pl + do.call("facet_grid", a.facet)
   }
   


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
After being deprecated since version 2.2.0, we've now made `facet_grid(facets)` defunct and your code should adapt.
You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
